### PR TITLE
chore: update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,23 +7,23 @@
 		"@nomicfoundation/hardhat-toolbox-viem": "^3.0.0",
 		"@nomicfoundation/hardhat-verify": "^2.0.0",
 		"@nomicfoundation/hardhat-viem": "^2.0.0",
-		"@types/chai": "^4.2.0",
-		"@types/chai-as-promised": "^7.1.6",
-		"@types/mocha": ">=9.1.0",
+		"@types/chai": "^4.3.20",
+		"@types/chai-as-promised": "^7.1.8",
+		"@types/mocha": "^10.0.10",
 		"@types/node": ">=18.0.0",
-		"chai": "^4.2.0",
+		"chai": "^4.5.0",
 		"hardhat": "^2.22.19",
 		"hardhat-gas-reporter": "^1.0.8",
-		"solidity-coverage": "^0.8.0",
-		"ts-node": ">=8.0.0",
-		"typescript": "~5.0.4",
-		"viem": "^2.7.6"
+		"solidity-coverage": "^0.8.17",
+		"ts-node": "^10.9.2",
+		"typescript": "^5.3.3",
+		"viem": "^2.43.5"
 	},
 	"dependencies": {
 		"@inco/lightning": "^0.7.6",
 		"@nomicfoundation/hardhat-toolbox": "^5.0.0",
-		"@openzeppelin/contracts": "^5.2.0",
-		"@openzeppelin/contracts-upgradeable": "^5.2.0",
-		"dotenv": "^16.4.7"
+		"@openzeppelin/contracts": "^5.4.0",
+		"@openzeppelin/contracts-upgradeable": "^5.4.0",
+		"dotenv": "^17.2.3"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,71 +13,71 @@ importers:
         version: 0.7.6
       '@nomicfoundation/hardhat-toolbox':
         specifier: ^5.0.0
-        version: 5.0.0(4aad595c92f35adb4df24a052e42e64f)
+        version: 5.0.0(5d99e244ba9990a185fd320000abe280)
       '@openzeppelin/contracts':
-        specifier: ^5.2.0
+        specifier: ^5.4.0
         version: 5.4.0
       '@openzeppelin/contracts-upgradeable':
-        specifier: ^5.2.0
+        specifier: ^5.4.0
         version: 5.4.0(@openzeppelin/contracts@5.4.0)
       dotenv:
-        specifier: ^16.4.7
-        version: 16.6.1
+        specifier: ^17.2.3
+        version: 17.2.3
     devDependencies:
       '@inco/js':
         specifier: ^0.7.6
-        version: 0.7.6(typescript@5.0.4)
+        version: 0.7.6(typescript@5.9.3)
       '@nomicfoundation/hardhat-ignition':
         specifier: ^0.15.0
-        version: 0.15.16(@nomicfoundation/hardhat-verify@2.1.3(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4)))(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4))
+        version: 0.15.16(@nomicfoundation/hardhat-verify@2.1.3(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3)))(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3))
       '@nomicfoundation/hardhat-ignition-viem':
         specifier: ^0.15.0
-        version: 0.15.16(@nomicfoundation/hardhat-ignition@0.15.16(@nomicfoundation/hardhat-verify@2.1.3(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4)))(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4)))(@nomicfoundation/hardhat-viem@2.1.3(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4))(typescript@5.0.4)(viem@2.43.5(typescript@5.0.4)))(@nomicfoundation/ignition-core@0.15.15)(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4))(viem@2.43.5(typescript@5.0.4))
+        version: 0.15.16(@nomicfoundation/hardhat-ignition@0.15.16(@nomicfoundation/hardhat-verify@2.1.3(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3)))(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3)))(@nomicfoundation/hardhat-viem@2.1.3(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3))(typescript@5.9.3)(viem@2.43.5(typescript@5.9.3)))(@nomicfoundation/ignition-core@0.15.15)(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3))(viem@2.43.5(typescript@5.9.3))
       '@nomicfoundation/hardhat-network-helpers':
         specifier: ^1.0.0
-        version: 1.1.2(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4))
+        version: 1.1.2(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3))
       '@nomicfoundation/hardhat-toolbox-viem':
         specifier: ^3.0.0
-        version: 3.0.0(b42da985c635a4d161f20eb329fc6e14)
+        version: 3.0.0(755f836065fa1ae4fc6ae76a1bffcf6d)
       '@nomicfoundation/hardhat-verify':
         specifier: ^2.0.0
-        version: 2.1.3(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4))
+        version: 2.1.3(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3))
       '@nomicfoundation/hardhat-viem':
         specifier: ^2.0.0
-        version: 2.1.3(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4))(typescript@5.0.4)(viem@2.43.5(typescript@5.0.4))
+        version: 2.1.3(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3))(typescript@5.9.3)(viem@2.43.5(typescript@5.9.3))
       '@types/chai':
-        specifier: ^4.2.0
+        specifier: ^4.3.20
         version: 4.3.20
       '@types/chai-as-promised':
-        specifier: ^7.1.6
+        specifier: ^7.1.8
         version: 7.1.8
       '@types/mocha':
-        specifier: '>=9.1.0'
+        specifier: ^10.0.10
         version: 10.0.10
       '@types/node':
         specifier: '>=18.0.0'
         version: 25.0.3
       chai:
-        specifier: ^4.2.0
+        specifier: ^4.5.0
         version: 4.5.0
       hardhat:
         specifier: ^2.22.19
-        version: 2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4)
+        version: 2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3)
       hardhat-gas-reporter:
         specifier: ^1.0.8
-        version: 1.0.10(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4))
+        version: 1.0.10(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3))
       solidity-coverage:
-        specifier: ^0.8.0
-        version: 0.8.17(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4))
+        specifier: ^0.8.17
+        version: 0.8.17(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3))
       ts-node:
-        specifier: '>=8.0.0'
-        version: 10.9.2(@types/node@25.0.3)(typescript@5.0.4)
+        specifier: ^10.9.2
+        version: 10.9.2(@types/node@25.0.3)(typescript@5.9.3)
       typescript:
-        specifier: ~5.0.4
-        version: 5.0.4
+        specifier: ^5.3.3
+        version: 5.9.3
       viem:
-        specifier: ^2.7.6
-        version: 2.43.5(typescript@5.0.4)
+        specifier: ^2.43.5
+        version: 2.43.5(typescript@5.9.3)
 
 packages:
 
@@ -1236,8 +1236,8 @@ packages:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
 
-  dotenv@16.6.1:
-    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+  dotenv@17.2.3:
+    resolution: {integrity: sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==}
     engines: {node: '>=12'}
 
   ds-test@https://codeload.github.com/dapphub/ds-test/tar.gz/e282159d5170298eb2455a6c05280ab5a73a4ef0:
@@ -2423,9 +2423,9 @@ packages:
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
-  typescript@5.0.4:
-    resolution: {integrity: sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==}
-    engines: {node: '>=12.20'}
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
     hasBin: true
 
   typical@4.0.0:
@@ -2997,7 +2997,7 @@ snapshots:
       protobufjs: 7.5.4
       yargs: 17.7.2
 
-  '@inco/js@0.7.6(typescript@5.0.4)':
+  '@inco/js@0.7.6(typescript@5.9.3)':
     dependencies:
       '@bufbuild/protobuf': 2.10.2
       '@connectrpc/connect': 2.1.1(@bufbuild/protobuf@2.10.2)
@@ -3009,7 +3009,7 @@ snapshots:
       effect: 3.19.14
       elliptic: 6.6.1
       sha3: 2.1.4
-      viem: 2.43.5(typescript@5.0.4)
+      viem: 2.43.5(typescript@5.9.3)
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -3115,51 +3115,51 @@ snapshots:
       '@nomicfoundation/edr-linux-x64-musl': 0.12.0-next.21
       '@nomicfoundation/edr-win32-x64-msvc': 0.12.0-next.21
 
-  '@nomicfoundation/hardhat-chai-matchers@2.1.0(@nomicfoundation/hardhat-ethers@3.1.3(ethers@6.16.0)(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4)))(chai@4.5.0)(ethers@6.16.0)(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4))':
+  '@nomicfoundation/hardhat-chai-matchers@2.1.0(@nomicfoundation/hardhat-ethers@3.1.3(ethers@6.16.0)(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3)))(chai@4.5.0)(ethers@6.16.0)(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3))':
     dependencies:
-      '@nomicfoundation/hardhat-ethers': 3.1.3(ethers@6.16.0)(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4))
+      '@nomicfoundation/hardhat-ethers': 3.1.3(ethers@6.16.0)(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3))
       '@types/chai-as-promised': 7.1.8
       chai: 4.5.0
       chai-as-promised: 7.1.2(chai@4.5.0)
       deep-eql: 4.1.4
       ethers: 6.16.0
-      hardhat: 2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4)
+      hardhat: 2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3)
       ordinal: 1.0.3
 
-  '@nomicfoundation/hardhat-ethers@3.1.3(ethers@6.16.0)(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4))':
+  '@nomicfoundation/hardhat-ethers@3.1.3(ethers@6.16.0)(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3))':
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       ethers: 6.16.0
-      hardhat: 2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4)
+      hardhat: 2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3)
       lodash.isequal: 4.5.0
     transitivePeerDependencies:
       - supports-color
 
-  '@nomicfoundation/hardhat-ignition-ethers@0.15.17(@nomicfoundation/hardhat-ethers@3.1.3(ethers@6.16.0)(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4)))(@nomicfoundation/hardhat-ignition@0.15.16(@nomicfoundation/hardhat-verify@2.1.3(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4)))(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4)))(@nomicfoundation/ignition-core@0.15.15)(ethers@6.16.0)(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4))':
+  '@nomicfoundation/hardhat-ignition-ethers@0.15.17(@nomicfoundation/hardhat-ethers@3.1.3(ethers@6.16.0)(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3)))(@nomicfoundation/hardhat-ignition@0.15.16(@nomicfoundation/hardhat-verify@2.1.3(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3)))(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3)))(@nomicfoundation/ignition-core@0.15.15)(ethers@6.16.0)(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3))':
     dependencies:
-      '@nomicfoundation/hardhat-ethers': 3.1.3(ethers@6.16.0)(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4))
-      '@nomicfoundation/hardhat-ignition': 0.15.16(@nomicfoundation/hardhat-verify@2.1.3(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4)))(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4))
+      '@nomicfoundation/hardhat-ethers': 3.1.3(ethers@6.16.0)(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3))
+      '@nomicfoundation/hardhat-ignition': 0.15.16(@nomicfoundation/hardhat-verify@2.1.3(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3)))(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3))
       '@nomicfoundation/ignition-core': 0.15.15
       ethers: 6.16.0
-      hardhat: 2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4)
+      hardhat: 2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3)
 
-  '@nomicfoundation/hardhat-ignition-viem@0.15.16(@nomicfoundation/hardhat-ignition@0.15.16(@nomicfoundation/hardhat-verify@2.1.3(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4)))(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4)))(@nomicfoundation/hardhat-viem@2.1.3(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4))(typescript@5.0.4)(viem@2.43.5(typescript@5.0.4)))(@nomicfoundation/ignition-core@0.15.15)(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4))(viem@2.43.5(typescript@5.0.4))':
+  '@nomicfoundation/hardhat-ignition-viem@0.15.16(@nomicfoundation/hardhat-ignition@0.15.16(@nomicfoundation/hardhat-verify@2.1.3(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3)))(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3)))(@nomicfoundation/hardhat-viem@2.1.3(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3))(typescript@5.9.3)(viem@2.43.5(typescript@5.9.3)))(@nomicfoundation/ignition-core@0.15.15)(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3))(viem@2.43.5(typescript@5.9.3))':
     dependencies:
-      '@nomicfoundation/hardhat-ignition': 0.15.16(@nomicfoundation/hardhat-verify@2.1.3(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4)))(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4))
-      '@nomicfoundation/hardhat-viem': 2.1.3(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4))(typescript@5.0.4)(viem@2.43.5(typescript@5.0.4))
+      '@nomicfoundation/hardhat-ignition': 0.15.16(@nomicfoundation/hardhat-verify@2.1.3(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3)))(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3))
+      '@nomicfoundation/hardhat-viem': 2.1.3(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3))(typescript@5.9.3)(viem@2.43.5(typescript@5.9.3))
       '@nomicfoundation/ignition-core': 0.15.15
-      hardhat: 2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4)
-      viem: 2.43.5(typescript@5.0.4)
+      hardhat: 2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3)
+      viem: 2.43.5(typescript@5.9.3)
 
-  '@nomicfoundation/hardhat-ignition@0.15.16(@nomicfoundation/hardhat-verify@2.1.3(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4)))(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4))':
+  '@nomicfoundation/hardhat-ignition@0.15.16(@nomicfoundation/hardhat-verify@2.1.3(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3)))(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3))':
     dependencies:
-      '@nomicfoundation/hardhat-verify': 2.1.3(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4))
+      '@nomicfoundation/hardhat-verify': 2.1.3(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3))
       '@nomicfoundation/ignition-core': 0.15.15
       '@nomicfoundation/ignition-ui': 0.15.13
       chalk: 4.1.2
       debug: 4.4.3(supports-color@8.1.1)
       fs-extra: 10.1.0
-      hardhat: 2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4)
+      hardhat: 2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3)
       json5: 2.2.3
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -3167,58 +3167,58 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@nomicfoundation/hardhat-network-helpers@1.1.2(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4))':
+  '@nomicfoundation/hardhat-network-helpers@1.1.2(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3))':
     dependencies:
       ethereumjs-util: 7.1.5
-      hardhat: 2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4)
+      hardhat: 2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3)
 
-  '@nomicfoundation/hardhat-toolbox-viem@3.0.0(b42da985c635a4d161f20eb329fc6e14)':
+  '@nomicfoundation/hardhat-toolbox-viem@3.0.0(755f836065fa1ae4fc6ae76a1bffcf6d)':
     dependencies:
-      '@nomicfoundation/hardhat-ignition-viem': 0.15.16(@nomicfoundation/hardhat-ignition@0.15.16(@nomicfoundation/hardhat-verify@2.1.3(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4)))(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4)))(@nomicfoundation/hardhat-viem@2.1.3(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4))(typescript@5.0.4)(viem@2.43.5(typescript@5.0.4)))(@nomicfoundation/ignition-core@0.15.15)(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4))(viem@2.43.5(typescript@5.0.4))
-      '@nomicfoundation/hardhat-network-helpers': 1.1.2(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4))
-      '@nomicfoundation/hardhat-verify': 2.1.3(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4))
-      '@nomicfoundation/hardhat-viem': 2.1.3(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4))(typescript@5.0.4)(viem@2.43.5(typescript@5.0.4))
+      '@nomicfoundation/hardhat-ignition-viem': 0.15.16(@nomicfoundation/hardhat-ignition@0.15.16(@nomicfoundation/hardhat-verify@2.1.3(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3)))(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3)))(@nomicfoundation/hardhat-viem@2.1.3(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3))(typescript@5.9.3)(viem@2.43.5(typescript@5.9.3)))(@nomicfoundation/ignition-core@0.15.15)(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3))(viem@2.43.5(typescript@5.9.3))
+      '@nomicfoundation/hardhat-network-helpers': 1.1.2(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3))
+      '@nomicfoundation/hardhat-verify': 2.1.3(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3))
+      '@nomicfoundation/hardhat-viem': 2.1.3(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3))(typescript@5.9.3)(viem@2.43.5(typescript@5.9.3))
       '@types/chai': 4.3.20
       '@types/chai-as-promised': 7.1.8
       '@types/mocha': 10.0.10
       '@types/node': 25.0.3
       chai: 4.5.0
       chai-as-promised: 7.1.2(chai@4.5.0)
-      hardhat: 2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4)
-      hardhat-gas-reporter: 1.0.10(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4))
-      solidity-coverage: 0.8.17(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4))
-      ts-node: 10.9.2(@types/node@25.0.3)(typescript@5.0.4)
-      typescript: 5.0.4
-      viem: 2.43.5(typescript@5.0.4)
+      hardhat: 2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3)
+      hardhat-gas-reporter: 1.0.10(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3))
+      solidity-coverage: 0.8.17(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3))
+      ts-node: 10.9.2(@types/node@25.0.3)(typescript@5.9.3)
+      typescript: 5.9.3
+      viem: 2.43.5(typescript@5.9.3)
 
-  '@nomicfoundation/hardhat-toolbox@5.0.0(4aad595c92f35adb4df24a052e42e64f)':
+  '@nomicfoundation/hardhat-toolbox@5.0.0(5d99e244ba9990a185fd320000abe280)':
     dependencies:
-      '@nomicfoundation/hardhat-chai-matchers': 2.1.0(@nomicfoundation/hardhat-ethers@3.1.3(ethers@6.16.0)(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4)))(chai@4.5.0)(ethers@6.16.0)(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4))
-      '@nomicfoundation/hardhat-ethers': 3.1.3(ethers@6.16.0)(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4))
-      '@nomicfoundation/hardhat-ignition-ethers': 0.15.17(@nomicfoundation/hardhat-ethers@3.1.3(ethers@6.16.0)(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4)))(@nomicfoundation/hardhat-ignition@0.15.16(@nomicfoundation/hardhat-verify@2.1.3(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4)))(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4)))(@nomicfoundation/ignition-core@0.15.15)(ethers@6.16.0)(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4))
-      '@nomicfoundation/hardhat-network-helpers': 1.1.2(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4))
-      '@nomicfoundation/hardhat-verify': 2.1.3(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4))
-      '@typechain/ethers-v6': 0.5.1(ethers@6.16.0)(typechain@8.3.2(typescript@5.0.4))(typescript@5.0.4)
-      '@typechain/hardhat': 9.1.0(@typechain/ethers-v6@0.5.1(ethers@6.16.0)(typechain@8.3.2(typescript@5.0.4))(typescript@5.0.4))(ethers@6.16.0)(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4))(typechain@8.3.2(typescript@5.0.4))
+      '@nomicfoundation/hardhat-chai-matchers': 2.1.0(@nomicfoundation/hardhat-ethers@3.1.3(ethers@6.16.0)(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3)))(chai@4.5.0)(ethers@6.16.0)(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3))
+      '@nomicfoundation/hardhat-ethers': 3.1.3(ethers@6.16.0)(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3))
+      '@nomicfoundation/hardhat-ignition-ethers': 0.15.17(@nomicfoundation/hardhat-ethers@3.1.3(ethers@6.16.0)(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3)))(@nomicfoundation/hardhat-ignition@0.15.16(@nomicfoundation/hardhat-verify@2.1.3(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3)))(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3)))(@nomicfoundation/ignition-core@0.15.15)(ethers@6.16.0)(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3))
+      '@nomicfoundation/hardhat-network-helpers': 1.1.2(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3))
+      '@nomicfoundation/hardhat-verify': 2.1.3(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3))
+      '@typechain/ethers-v6': 0.5.1(ethers@6.16.0)(typechain@8.3.2(typescript@5.9.3))(typescript@5.9.3)
+      '@typechain/hardhat': 9.1.0(@typechain/ethers-v6@0.5.1(ethers@6.16.0)(typechain@8.3.2(typescript@5.9.3))(typescript@5.9.3))(ethers@6.16.0)(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3))(typechain@8.3.2(typescript@5.9.3))
       '@types/chai': 4.3.20
       '@types/mocha': 10.0.10
       '@types/node': 25.0.3
       chai: 4.5.0
       ethers: 6.16.0
-      hardhat: 2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4)
-      hardhat-gas-reporter: 1.0.10(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4))
-      solidity-coverage: 0.8.17(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4))
-      ts-node: 10.9.2(@types/node@25.0.3)(typescript@5.0.4)
-      typechain: 8.3.2(typescript@5.0.4)
-      typescript: 5.0.4
+      hardhat: 2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3)
+      hardhat-gas-reporter: 1.0.10(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3))
+      solidity-coverage: 0.8.17(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3))
+      ts-node: 10.9.2(@types/node@25.0.3)(typescript@5.9.3)
+      typechain: 8.3.2(typescript@5.9.3)
+      typescript: 5.9.3
 
-  '@nomicfoundation/hardhat-verify@2.1.3(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4))':
+  '@nomicfoundation/hardhat-verify@2.1.3(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3))':
     dependencies:
       '@ethersproject/abi': 5.8.0
       '@ethersproject/address': 5.8.0
       cbor: 8.1.0
       debug: 4.4.3(supports-color@8.1.1)
-      hardhat: 2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4)
+      hardhat: 2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3)
       lodash.clonedeep: 4.5.0
       picocolors: 1.1.1
       semver: 6.3.1
@@ -3227,12 +3227,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@nomicfoundation/hardhat-viem@2.1.3(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4))(typescript@5.0.4)(viem@2.43.5(typescript@5.0.4))':
+  '@nomicfoundation/hardhat-viem@2.1.3(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3))(typescript@5.9.3)(viem@2.43.5(typescript@5.9.3))':
     dependencies:
-      abitype: 0.9.10(typescript@5.0.4)
-      hardhat: 2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4)
+      abitype: 0.9.10(typescript@5.9.3)
+      hardhat: 2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3)
       lodash.memoize: 4.1.2
-      viem: 2.43.5(typescript@5.0.4)
+      viem: 2.43.5(typescript@5.9.3)
     transitivePeerDependencies:
       - typescript
       - zod
@@ -3419,21 +3419,21 @@ snapshots:
 
   '@tsconfig/node16@1.0.4': {}
 
-  '@typechain/ethers-v6@0.5.1(ethers@6.16.0)(typechain@8.3.2(typescript@5.0.4))(typescript@5.0.4)':
+  '@typechain/ethers-v6@0.5.1(ethers@6.16.0)(typechain@8.3.2(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
       ethers: 6.16.0
       lodash: 4.17.21
-      ts-essentials: 7.0.3(typescript@5.0.4)
-      typechain: 8.3.2(typescript@5.0.4)
-      typescript: 5.0.4
+      ts-essentials: 7.0.3(typescript@5.9.3)
+      typechain: 8.3.2(typescript@5.9.3)
+      typescript: 5.9.3
 
-  '@typechain/hardhat@9.1.0(@typechain/ethers-v6@0.5.1(ethers@6.16.0)(typechain@8.3.2(typescript@5.0.4))(typescript@5.0.4))(ethers@6.16.0)(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4))(typechain@8.3.2(typescript@5.0.4))':
+  '@typechain/hardhat@9.1.0(@typechain/ethers-v6@0.5.1(ethers@6.16.0)(typechain@8.3.2(typescript@5.9.3))(typescript@5.9.3))(ethers@6.16.0)(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3))(typechain@8.3.2(typescript@5.9.3))':
     dependencies:
-      '@typechain/ethers-v6': 0.5.1(ethers@6.16.0)(typechain@8.3.2(typescript@5.0.4))(typescript@5.0.4)
+      '@typechain/ethers-v6': 0.5.1(ethers@6.16.0)(typechain@8.3.2(typescript@5.9.3))(typescript@5.9.3)
       ethers: 6.16.0
       fs-extra: 9.1.0
-      hardhat: 2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4)
-      typechain: 8.3.2(typescript@5.0.4)
+      hardhat: 2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3)
+      typechain: 8.3.2(typescript@5.9.3)
 
   '@types/bn.js@5.2.0':
     dependencies:
@@ -3494,13 +3494,13 @@ snapshots:
 
   abbrev@1.0.9: {}
 
-  abitype@0.9.10(typescript@5.0.4):
+  abitype@0.9.10(typescript@5.9.3):
     optionalDependencies:
-      typescript: 5.0.4
+      typescript: 5.9.3
 
-  abitype@1.2.3(typescript@5.0.4):
+  abitype@1.2.3(typescript@5.9.3):
     optionalDependencies:
-      typescript: 5.0.4
+      typescript: 5.9.3
 
   acorn-walk@8.3.4:
     dependencies:
@@ -3900,7 +3900,7 @@ snapshots:
     dependencies:
       path-type: 4.0.0
 
-  dotenv@16.6.1: {}
+  dotenv@17.2.3: {}
 
   ds-test@https://codeload.github.com/dapphub/ds-test/tar.gz/e282159d5170298eb2455a6c05280ab5a73a4ef0: {}
 
@@ -4340,11 +4340,11 @@ snapshots:
     optionalDependencies:
       uglify-js: 3.19.3
 
-  hardhat-gas-reporter@1.0.10(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4)):
+  hardhat-gas-reporter@1.0.10(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3)):
     dependencies:
       array-uniq: 1.0.3
       eth-gas-reporter: 0.2.27
-      hardhat: 2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4)
+      hardhat: 2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3)
       sha1: 1.1.1
     transitivePeerDependencies:
       - '@codechecks/client'
@@ -4352,7 +4352,7 @@ snapshots:
       - debug
       - utf-8-validate
 
-  hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4):
+  hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3):
     dependencies:
       '@ethereumjs/util': 9.1.0
       '@ethersproject/abi': 5.8.0
@@ -4394,8 +4394,8 @@ snapshots:
       uuid: 8.3.2
       ws: 7.5.10
     optionalDependencies:
-      ts-node: 10.9.2(@types/node@25.0.3)(typescript@5.0.4)
-      typescript: 5.0.4
+      ts-node: 10.9.2(@types/node@25.0.3)(typescript@5.9.3)
+      typescript: 5.9.3
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -4763,7 +4763,7 @@ snapshots:
 
   os-tmpdir@1.0.2: {}
 
-  ox@0.11.1(typescript@5.0.4):
+  ox@0.11.1(typescript@5.9.3):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/ciphers': 1.3.0
@@ -4771,10 +4771,10 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@5.0.4)
+      abitype: 1.2.3(typescript@5.9.3)
       eventemitter3: 5.0.1
     optionalDependencies:
-      typescript: 5.0.4
+      typescript: 5.9.3
     transitivePeerDependencies:
       - zod
 
@@ -5078,7 +5078,7 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  solidity-coverage@0.8.17(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4)):
+  solidity-coverage@0.8.17(hardhat@2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3)):
     dependencies:
       '@ethersproject/abi': 5.8.0
       '@solidity-parser/parser': 0.20.2
@@ -5089,7 +5089,7 @@ snapshots:
       ghost-testrpc: 0.0.2
       global-modules: 2.0.0
       globby: 10.0.2
-      hardhat: 2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4))(typescript@5.0.4)
+      hardhat: 2.28.2(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3)
       jsonschema: 1.5.0
       lodash: 4.17.21
       mocha: 10.8.2
@@ -5249,11 +5249,11 @@ snapshots:
       command-line-usage: 6.1.3
       string-format: 2.0.0
 
-  ts-essentials@7.0.3(typescript@5.0.4):
+  ts-essentials@7.0.3(typescript@5.9.3):
     dependencies:
-      typescript: 5.0.4
+      typescript: 5.9.3
 
-  ts-node@10.9.2(@types/node@25.0.3)(typescript@5.0.4):
+  ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.12
@@ -5267,7 +5267,7 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 5.0.4
+      typescript: 5.9.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
@@ -5296,7 +5296,7 @@ snapshots:
 
   type-fest@0.7.1: {}
 
-  typechain@8.3.2(typescript@5.0.4):
+  typechain@8.3.2(typescript@5.9.3):
     dependencies:
       '@types/prettier': 2.7.3
       debug: 4.4.3(supports-color@8.1.1)
@@ -5307,8 +5307,8 @@ snapshots:
       mkdirp: 1.0.4
       prettier: 2.8.8
       ts-command-line-args: 2.5.1
-      ts-essentials: 7.0.3(typescript@5.0.4)
-      typescript: 5.0.4
+      ts-essentials: 7.0.3(typescript@5.9.3)
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
@@ -5320,7 +5320,7 @@ snapshots:
 
   typedarray@0.0.6: {}
 
-  typescript@5.0.4: {}
+  typescript@5.9.3: {}
 
   typical@4.0.0: {}
 
@@ -5351,18 +5351,18 @@ snapshots:
 
   v8-compile-cache-lib@3.0.1: {}
 
-  viem@2.43.5(typescript@5.0.4):
+  viem@2.43.5(typescript@5.9.3):
     dependencies:
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@5.0.4)
+      abitype: 1.2.3(typescript@5.9.3)
       isows: 1.0.7(ws@8.18.3)
-      ox: 0.11.1(typescript@5.0.4)
+      ox: 0.11.1(typescript@5.9.3)
       ws: 8.18.3
     optionalDependencies:
-      typescript: 5.0.4
+      typescript: 5.9.3
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate


### PR DESCRIPTION
- Bumped versions for several dependencies including @types/chai, chai, dotenv, and typescript.
- Updated hardhat and related packages to ensure compatibility with the latest TypeScript version.
- Adjusted package versions for @openzeppelin/contracts and @openzeppelin/contracts-upgradeable to 5.4.0.
- Ensured all changes are reflected in pnpm-lock.yaml for consistency.